### PR TITLE
Clone original file prior to modifying

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ var gulpGm = function (modifier, options) {
     _gm = gm.subClass({ imageMagick : true });
   }
 
-  return through.obj(function (file, enc, done) {
+  return through.obj(function (originalFile, enc, done) {
+
+    var file = originalFile.clone({contents: false});
 
     if (file.isNull()) {
       return done(null, file);


### PR DESCRIPTION
When this module is used in a split pipeline it does strange things because it's referencing the content which may have been modified elsewhere in the same pipeline.